### PR TITLE
Update shipping_addresses html & css

### DIFF
--- a/app/assets/stylesheets/shipping_addresses.scss
+++ b/app/assets/stylesheets/shipping_addresses.scss
@@ -1,3 +1,38 @@
 // Place all the styles related to the shipping_addresses controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+.shipping-contents {
+  padding: 20px;
+}
+
+.shipping-container h1 {
+  margin-left: 100px;
+  margin-bottom: 30px;
+  background-color: #eeeeee;
+  font-size: 24px;
+  display: inline-block;
+}
+
+.sh-tb td,.sh-tb tr,.sh-tb th {
+  height: 50px;
+  padding: 5px;
+}
+
+.sh-tr th,.sh-tr td {
+  border: solid 1px black;
+}
+
+.shipping-form-table td {
+  height: 30px;
+  padding: 5px;
+}
+
+.sh-form {
+  margin: 20px;
+}
+
+.sh-form-td {
+  width: 200px;
+  padding-left: 10px;
+}

--- a/app/views/shipping_addresses/_new.html.erb
+++ b/app/views/shipping_addresses/_new.html.erb
@@ -1,17 +1,17 @@
-<div class="table">
+<div class="shipping-form-table">
   <%= form_for [member,shipping] do |f| %>
     <table>
       <tbody>
           <tr>
-            <td>郵便番号（ハイフンなし）</td>
-            <td><%= f.text_field :postal_code %></td>
+            <td><%= f.label :postal_code, "郵便番号（ハイフンなし）", class: "sh-form-td" %></td>
+            <td><%= f.text_field :postal_code, placeholder: "1234567" %></td>
           </tr>
           <tr>
-            <td>住所</td>
-            <td><%= f.text_field :address %></td>
+            <td><%= f.label :address, "住所", class: "sh-form-td" %></td>
+            <td><%= f.text_field :address, size: "40" %></td>
           </tr>
           <tr>
-            <td>宛名</td>
+            <td><%= f.label :receiver, "宛名", class: "sh-form-td" %></td>
             <td><%= f.text_field :receiver %></td>
           </tr>
           <tr>

--- a/app/views/shipping_addresses/edit.html.erb
+++ b/app/views/shipping_addresses/edit.html.erb
@@ -1,6 +1,8 @@
-<div>
-  <h1>配送先編集</h1>
-
-  <%= render partial: 'new', locals: { member: @member, shipping: @shipping, submit: "編集する", color: "btn-primary" } %>
-
+<div class="shipping-contents">
+  <div class="shipping-container">
+    <div class="sh-form shipping-edit">
+      <h1>配送先編集</h1>
+      <%= render partial: 'new', locals: { member: @member, shipping: @shipping, submit: "編集する", color: "btn-primary" } %>
+    </div>
+  </div>
 </div>

--- a/app/views/shipping_addresses/index.html.erb
+++ b/app/views/shipping_addresses/index.html.erb
@@ -1,31 +1,33 @@
-<div>
-  <h1>配送先登録／一覧</h1>
-
-  <%= render partial: 'new', locals: { member: @member, shipping: @shipping, submit: "登録する", color: "btn-success" } %>
-
-  <div class = "table">
-    <table>
-      <thead>
-        <tr>
-          <th>郵便番号</th>
-          <th>住所</th>
-          <th>宛名</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @member.shipping_addresses.each do |shipping| %>
-          <tr>
-            <td><%= shipping.postal_code %></td>
-            <td><%= shipping.address %></td>
-            <td><%= shipping.receiver %></td>
-            <td>
-              <%= link_to '編集する', edit_member_shipping_address_path(shipping.member,shipping), class: "btn btn-primary" %>
-              <%= link_to '削除する', member_shipping_address_path(shipping.member,shipping), method: :delete, class: "btn btn-danger" %>
-            </td>
+<div class="shipping-contents">
+  <div class="shipping-container">
+    <div class="sh-form shipping-new">
+      <h1>配送先登録／一覧</h1>
+      <%= render partial: 'new', locals: { member: @member, shipping: @shipping, submit: "登録する", color: "btn-success" } %>
+    </div>
+    <div class = "shipping-index-table">
+      <table class="sh-tb">
+        <thead>
+          <tr class="sh-tr">
+            <th>郵便番号</th>
+            <th>住所</th>
+            <th>宛名</th>
+            <th></th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @member.shipping_addresses.each do |shipping| %>
+            <tr class="sh-tr">
+              <td><%= shipping.postal_code.to_s.insert(3, "-") %></td>
+              <td><%= shipping.address %></td>
+              <td><%= shipping.receiver %></td>
+              <td>
+                <%= link_to '編集する', edit_member_shipping_address_path(shipping.member,shipping), class: "btn btn-primary" %>
+                <%= link_to '削除する', member_shipping_address_path(shipping.member,shipping), method: :delete, class: "btn btn-danger" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
・見た目をUIフレームに近づけています。

・配送先一覧の郵便番号に
`postal_code.to_s.insert(3,"-")`
を追記してハイフンが表示されるようになっています。

・郵便番号の入力フォームに
`placeholder: "1234567"`
を追記してデフォルト数値1234567がフォーム上に薄く表示されています。（入力し始めると消えます。）